### PR TITLE
Change imports from `.d.ts` to use `type`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
-import QmlWorkspace from "./qmlWorkspace";
-import JsWorkspace from "./jsWorkspace";
+import type QmlWorkspace from "./qmlWorkspace";
+import type JsWorkspace from "./jsWorkspace";
 import Options from "./options";
-import QmlKWin from "./qmlKWin";
-import JsKWin from "./jsKWin";
+import type QmlKWin from "./qmlKWin";
+import type JsKWin from "./jsKWin";
 
-import VirtualDesktop from "./virtualdesktop";
-import Output from "./output";
-import TileManager from "./tilemanager";
-import TileModel from "./tilemodel";
-import Tile from "./tile";
-import Window from "./window";
-import DBusCall from "./qml/dbuscall";
-import ShortcutHandler from "./qml/shortcutHandler";
+import type VirtualDesktop from "./virtualdesktop";
+import type Output from "./output";
+import type TileManager from "./tilemanager";
+import type TileModel from "./tilemodel";
+import type Tile from "./tile";
+import type Window from "./window";
+import type DBusCall from "./qml/dbuscall";
+import type ShortcutHandler from "./qml/shortcutHandler";
 import {LayoutDirection, ClientAreaOption, Edge, MaximizeMode} from "./enums";
 
 export {

--- a/src/jsKWin.d.ts
+++ b/src/jsKWin.d.ts
@@ -1,4 +1,4 @@
-import QmlKWin from "./qmlKWin";
+import type QmlKWin from "./qmlKWin";
 
 // js gets more stuff because they can't construct qml objects
 export default interface JsKWin extends QmlKWin {

--- a/src/jsWorkspace.d.ts
+++ b/src/jsWorkspace.d.ts
@@ -1,5 +1,5 @@
 import Workspace from "./workspace";
-import Window from "./window";
+import type Window from "./window";
 
 export default interface JsWorkspace extends Workspace {
     windowList(): Window[];

--- a/src/qml/dbuscall.d.ts
+++ b/src/qml/dbuscall.d.ts
@@ -1,4 +1,4 @@
-import Signal from "../qt/signal";
+import type Signal from "../qt/signal";
 
 export default interface DBusCall {
     dbusInterface: string;

--- a/src/qml/shortcutHandler.d.ts
+++ b/src/qml/shortcutHandler.d.ts
@@ -1,9 +1,9 @@
-import Signal from "../qt/signal";
+import type Signal from "../qt/signal";
 
 export default interface ShortcutHandler {
     name: string;
     text: string;
     sequence: string;
-    
+
     activated: Signal<() => void>;
 }

--- a/src/qmlWorkspace.d.ts
+++ b/src/qmlWorkspace.d.ts
@@ -1,5 +1,5 @@
 import Workspace from "./workspace";
-import Window from "./window";
+import type Window from "./window";
 
 export default interface QmlWorkspace extends Workspace {
     windows: Window[];

--- a/src/qt/index.ts
+++ b/src/qt/index.ts
@@ -1,10 +1,10 @@
-import QPoint from "./qpoint";
-import QRect from "./qrect";
-import QSize from "./qsize";
-import QIcon from "./qicon";
-import QUuid from "./quuid";
-import QTimer from "./qtimer";
-import Signal from "./signal";
+import type QPoint from "./qpoint";
+import type QRect from "./qrect";
+import type QSize from "./qsize";
+import type QIcon from "./qicon";
+import type QUuid from "./quuid";
+import type QTimer from "./qtimer";
+import type Signal from "./signal";
 
 export {
     QPoint,

--- a/src/qt/qrect.d.ts
+++ b/src/qt/qrect.d.ts
@@ -1,5 +1,5 @@
-import QPoint from "./qpoint";
-import QSize from "./qsize";
+import type QPoint from "./qpoint";
+import type QSize from "./qsize";
 
 export default interface QRect extends QPoint, QSize {
     // nothing else to say

--- a/src/qt/qtimer.d.ts
+++ b/src/qt/qtimer.d.ts
@@ -1,4 +1,4 @@
-import Signal from "./signal";
+import type Signal from "./signal";
 
 export default interface QTimer {
     interval: number;

--- a/src/tile.d.ts
+++ b/src/tile.d.ts
@@ -1,7 +1,7 @@
 import QRect from "./qt/qrect";
 import Signal from "./qt/signal";
 
-import Window from "./window";
+import type Window from "./window";
 import {LayoutDirection, Edge} from "./enums";
 
 export default interface Tile {

--- a/src/tilemanager.d.ts
+++ b/src/tilemanager.d.ts
@@ -1,8 +1,8 @@
 import QPoint from "./qt/qpoint";
 import Signal from "./qt/signal";
 
-import TileModel from "./tilemodel";
-import Tile from "./tile";
+import type TileModel from "./tilemodel";
+import type Tile from "./tile";
 
 export default interface TileManager {
     rootTile: Tile;

--- a/src/window.d.ts
+++ b/src/window.d.ts
@@ -5,9 +5,9 @@ import QUuid from "./qt/quuid";
 import Signal from "./qt/signal";
 import QIcon from "./qt/qicon";
 
-import Output from "./output";
-import Tile from "./tile";
-import VirtualDesktop from "./virtualdesktop";
+import type Output from "./output";
+import type Tile from "./tile";
+import type VirtualDesktop from "./virtualdesktop";
 import {MaximizeMode} from "./enums";
 
 export default interface Window {

--- a/src/workspace.d.ts
+++ b/src/workspace.d.ts
@@ -3,10 +3,10 @@ import QRect from "./qt/qrect";
 import QSize from "./qt/qsize";
 import Signal from "./qt/signal";
 
-import VirtualDesktop from "./virtualdesktop";
-import Window from "./window";
-import Output from "./output";
-import TileManager from "./tilemanager";
+import type VirtualDesktop from "./virtualdesktop";
+import type Window from "./window";
+import type Output from "./output";
+import type TileManager from "./tilemanager";
 import {ClientAreaOption} from "./enums";
 
 export default interface Workspace {


### PR DESCRIPTION
This applies the tip in https://github.com/zeroxoneafour/polonium/pull/98#issuecomment-1962739413.

All imports that import stuff from a `.d.ts` file should `import type Foo from ...` instead of `import Foo from ...`. This appears to have fixed the build entirely for me.

Note: this is a very quick PR. I see that my editor added a final newline and removed trailing whitespace. I could fix that if desired and amend the commit :+1:

Here's proof of `polonium` building on the `v1.0` branch for me (note: I switched `kpackagetool6` to `kpackagetool5` temporarily due to the former seemingly not being packaged in Nixpkgs yet):

<details>
<summary>build logs</summary>

```
[direnv]~/P/polonium v1.0• 2.5s | 2 ❱ make
cp -f res/metadata.json pkg/
cp -f res/main.xml pkg/contents/config/
cp -f res/config.ui pkg/contents/ui/
cp -f res/main.js pkg/contents/code/
sed -i "s/%VERSION%/1.0.0/" pkg/metadata.json
sed -i "s/%NAME%/polonium/" pkg/metadata.json
npm install

up to date, audited 136 packages in 828ms

34 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
npx esbuild --bundle src/index.ts --outfile=polonium.mjs --format=esm --platform=neutral

  polonium.mjs  57.4kb

⚡ Done in 7ms
mv -f polonium.mjs pkg/contents/code/main.mjs
cp -f src/qml/* pkg/contents/ui/
zip -r polonium.kwinscript pkg
  adding: pkg/ (stored 0%)
  adding: pkg/metadata.json (deflated 50%)
  adding: pkg/contents/ (stored 0%)
  adding: pkg/contents/code/ (stored 0%)
  adding: pkg/contents/code/main.mjs (deflated 81%)
  adding: pkg/contents/code/main.js (deflated 18%)
  adding: pkg/contents/config/ (stored 0%)
  adding: pkg/contents/config/main.xml (deflated 69%)
  adding: pkg/contents/ui/ (stored 0%)
  adding: pkg/contents/ui/main.qml (deflated 71%)
  adding: pkg/contents/ui/shortcuts.qml (deflated 58%)
  adding: pkg/contents/ui/settings.qml (deflated 76%)
  adding: pkg/contents/ui/dbus.qml (deflated 79%)
  adding: pkg/contents/ui/config.ui (deflated 85%)
kpackagetool5 -t KWin/Script -s polonium \
        && kpackagetool5 -t KWin/Script -u polonium.kwinscript \
        || kpackagetool5 -t KWin/Script -i polonium.kwinscript
Showing info for package: polonium
      Name : Polonium
   Comment : 
    Plugin : polonium
    Author : Vaughan Milliman
      Path : /home/falco/.local/share/kwin/scripts/polonium/
Upgrading package from file: /home/falco/Programs/polonium/polonium.kwinscript
Successfully upgraded /home/falco/Programs/polonium/polonium.kwinscript
rm -r pkg
rm polonium.kwinscript
```

</details>